### PR TITLE
fix: clear applied $externalResults on $model change when rules recompute

### DIFF
--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -466,7 +466,8 @@ export function setValidations ({
         const s = unwrap(state)
         const external = unwrap(externalResults)
         if (external) {
-          external[key] = cachedExternalResults[key]
+          // https://github.com/vuelidate/vuelidate/issues/1232
+          external[key] = undefined
         }
         if (isRef(s[key])) {
           s[key].value = val


### PR DESCRIPTION
fixes upstream https://github.com/vuelidate/vuelidate/issues/1232

There's is PR already made to the original repo, but it's abandoned, so we cannot expect anything to be merged.