### PR TITLE
App Feature Requirment: $silentInvalid fields.

### DIFF
--- a/packages/test-project/src/App.vue
+++ b/packages/test-project/src/App.vue
@@ -52,6 +52,11 @@
             $rewardEarly
           </router-link>
         </li>
+        <li>
+          <router-link to="/silent-invalids">
+            $silentInvalids
+          </router-link>
+        </li>
       </ul>
     </div>
     <router-view />

--- a/packages/test-project/src/components/SilentInvalids.vue
+++ b/packages/test-project/src/components/SilentInvalids.vue
@@ -59,7 +59,23 @@ const rules = computed(() => ({
   }, {})
 }))
 
-const v$ = useVuelidate(rules, state, { $rewardEarly: true })
+const v$ = useVuelidate(rules, state, { $rewardEarly: true, $useSilentInvalids: true })
+
+const requiredFields = computed(() => {
+  return v$.value.$silentInvalids
+    .filter((error) => error.$validator.includes('required'))
+    .map((error) => error.$propertyPath)
+})
+
+const invalidFields = computed(() => {
+  return v$.value.$errors
+    .map((error) => error.$propertyPath)
+    .filter((value, index, array) => array.indexOf(value) === index)
+})
+
+const test = computed(() => {
+  return [...requiredFields.value, ...invalidFields.value]
+})
 </script>
 
 <template>
@@ -139,6 +155,13 @@ const v$ = useVuelidate(rules, state, { $rewardEarly: true })
       Add contact
     </button>
 
-    <pre><code>{{ { vue: version } }}</code></pre>
+    <pre class="logger"><code>{{ { vue: version, "required fields left": requiredFields.length, "required fields paths": requiredFields, test: test.length } }}</code></pre>
   </div>
 </template>
+
+<style>
+.logger {
+  background: black;
+  color: lime;
+}
+</style>

--- a/packages/test-project/src/routes.js
+++ b/packages/test-project/src/routes.js
@@ -8,6 +8,7 @@ import ExternalValidationsForm from './components/ExternalValidationsForm.vue'
 import AsyncValidators from './components/AsyncValidators.vue'
 import NestedValidationsWithScopes from './components/NestedValidationsWithScopes/ParentValidator.vue'
 import RewardEarly from './components/RewardEarly.vue'
+import SilentInvalids from './components/SilentInvalids.vue'
 
 export const routes = [
   {
@@ -49,5 +50,9 @@ export const routes = [
   {
     path: '/reward-early',
     component: RewardEarly
+  },
+  {
+    path: '/silent-invalids',
+    component: SilentInvalids
   }
 ]

--- a/packages/vuelidate/README.md
+++ b/packages/vuelidate/README.md
@@ -1,3 +1,12 @@
+# Scoped features
+These features are not present at `vuelidate` and would probably never be as they
+fall into a project-specific category.
+
+1. `v$.$silentInvalids`. Enabled via `$useSilentInvalids: true` config flag,
+  exposes all invalid fields, **upfront**, into an array and recomputes on form
+  `state` changes. Useful to create counters like "how many required fields are
+  yet to be filled", which is the original case for the feature.
+
 # vuelidate
 
 > Simple, lightweight model-based validation for Vue.js 2.x & 3.0

--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -104,6 +104,7 @@ export type BaseValidation <
   readonly $error: boolean
   readonly $errors: ErrorObject[]
   readonly $silentErrors: ErrorObject[]
+  readonly $silentInvalids: ErrorObject[]
   readonly $externalResults: ({ $validator: '$externalResults', $response: null, $pending: false, $params: {} } & ErrorObject)[]
   readonly $invalid: boolean
   readonly $anyDirty: boolean
@@ -177,6 +178,7 @@ export interface GlobalConfig {
   $lazy?: boolean,
   $externalResults?: ServerErrors | Ref<ServerErrors> | UnwrapRef<ServerErrors>,
   $rewardEarly?: boolean,
+  $useSilentInvalids?: boolean,
   currentVueInstance?: ComponentInternalInstance | null
 }
 

--- a/packages/vuelidate/src/index.js
+++ b/packages/vuelidate/src/index.js
@@ -14,6 +14,7 @@ import { ComputedProxyFactory } from './utils/ComputedProxyFactory'
  * @property {Boolean} [$autoDirty] - Should the form watch for state changed, and automatically set `$dirty` to true.
  * @property {Boolean} [$lazy] - Should the validations be lazy, and run only after they are dirty
  * @property {Boolean} [$rewardEarly] - Once valid, re-runs property validators only on manual calls of $commit
+ * @property {Boolean} [$useSilentInvalids] - expose an $silentInvalids array with all invalid fields upfront and on model change
  */
 
 /**


### PR DESCRIPTION
## Summary

This new `$silentInvalids` computed property will allow us to evaluate current form required fields, being them static or dynamic/conditional required as it recomputes on $model changes. The feature is behind `$useSilentInvalids` config because this something that obviously impacts performance (even if not noticiable) as validators need to run every time model changes. Also it makes it clear that this is "personal" feature not something that would be available in `vuelidate` original repo.

## Details

1. The trick is to run validators on model change. This will push "invalid" fields to an array. This errors are not displayed in the ui (hence the `$silentInvalids` name). We can now filter the array of errors by the "required" validator key or other identifiable trait and create the "required fields widget" that is spec-ed in the [linear ticket](https://linear.app/gleamio/issue/GLM-4797).
1. `$silentInvalids` is very similar to vuelidates `$silentErrors`, but these are used as displayable errors and are **only computed when the field is dirty**, this means that we couldn't now if a field is required/conditional required until we interact with it. And this is not what we want because we need to show the widget with the list of required fields upfront. Secnarios like dynamic fieldsets with required (collections) `$silentErrors` when CRUDing or conditional required fields would not be listed when the sibling field value that made it true was changed.


## Notes

Close after #2 and rebase.