### PR TITLE
feat: forward  rule prop to result

### DIFF
--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -18,6 +18,7 @@ const ROOT_PATH = '__root'
  * @property {String | Ref<String> | function(*): string} [$message]
  * @property {Object | Ref<Object>} [$params]
  * @property {Object | Ref<Object>} [$async]
+ * @property {Ref<boolean|null>|undefined} [$active]
  * @property {Ref<*>[]} [$watchTargets]
  */
 

--- a/packages/vuelidate/src/utils/createResults.js
+++ b/packages/vuelidate/src/utils/createResults.js
@@ -1,4 +1,4 @@
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, isRef } from 'vue'
 import { isFunction, unwrap, unwrapObj } from '../utils'
 
 /**
@@ -171,6 +171,25 @@ function createSyncResult (
 }
 
 /**
+ * @note [A]
+ *   Forward forward of the $active property from validator rule itself into the
+ *   validation result, to be consumed/check via the validationState.
+ *   It is a way to solve two related issues with the current implementation of
+ *   $active as a side effect of running the validator for conditional rules:
+ *   1. Infinite loop when adding reactive properties to $params
+ *      https://linear.app/gleamio/issue/GLM-9612
+ *   2. Workaround of adding "unstable" unique `id` landed in `$params` messing up
+ *      the validation results for createAsyncResult
+ *      https://linear.app/gleamio/issue/GLM-14225
+ *
+ * @todo [A]
+ *   Implement a pure active conditional like Regle's — or just migrate to Regle
+ *   anyways as vuelidate is dead software, and Regle's api is just better while
+ *   similar to vuelidate.
+ *   https://reglejs.dev/core-concepts/rules/reusable-rules#active-property
+ *   https://reglejs.dev/core-concepts/rules/rules-operators#applyif
+ *
+ *
  * Returns the validation result.
  * Detects async and sync validators.
  * @param {NormalizedValidator} rule
@@ -202,6 +221,11 @@ export function createValidatorResult (
   const $pending = ref(false)
   const $params = rule.$params || {}
   const $response = ref(null)
+  // @note [A]
+  const $active = rule.$active !== undefined
+    ? (isRef(rule.$active) ? rule.$active : ref(!!rule.$active))
+    : ref(true)
+
   let $invalid
   let $unwatch
   let $silentInvalid
@@ -257,6 +281,7 @@ export function createValidatorResult (
     $invalid,
     $response,
     $unwatch,
-    $silentInvalid
+    $silentInvalid,
+    $active // @note [A]
   }
 }


### PR DESCRIPTION
Necessary feature to fix main app bug.

## Summary

Forwards an `$active` ref property from conditional validation rule definitions (`When` helper), allows it to be forward from the rule to returned `validationState` which our "required fields widget" needs, while not triggering infinite loops neither validation affecting results cache [^1] which the current solution `When() + _.uniqueId as $params.id` [^2] 

More info: https://github.com/Crowd9/Gleam/pull/31787


[^1]: https://linear.app/gleamio/issue/GLM-9612
[^2]: https://linear.app/gleamio/issue/GLM-14225


## Notes

- This is an "add only" feature, it doesn't break or tweak any existent behaviour, if you don't add an $active prop to your validators everything works business as usual
- Also note that with this current implementation, active is not computed internally which means that by itself it does not prevent validator functions from running. Currently it is only used for our `When` validator which does that implementation. I have a plan for doing it internally, but out of scope of this release